### PR TITLE
Improve streamlit setup steps + align stt api response with test audio sample

### DIFF
--- a/streamlitDemo/README.md
+++ b/streamlitDemo/README.md
@@ -2,10 +2,9 @@
 
 ## Setup
 - The demo app can be run locally. Follow steps here to setup a python environment for streamlit https://docs.streamlit.io/library/get-started/installation
-- Install dependencies in the virtual python environment by running command `pip install -r requirements.txt`
 
 ## Deploy
-- From the local repo directory `/nsmqai/streamlitDemo`, run command from the virtual environment terminal `streamlit run NSQM_AI.py`
+- From the local repo directory `/nsmqai/streamlitDemo`, run command from the virtual environment terminal `python start_nsmqai.py`
 - WebApp will be deployed at `http://localhost:8501/`
 
 ![homepage](./images/homepage.png)

--- a/streamlitDemo/start_nsmqai.py
+++ b/streamlitDemo/start_nsmqai.py
@@ -1,0 +1,20 @@
+import subprocess
+
+headerString = '''
+##################################################
+#########         NSMQ AI Web App        #########
+##################################################
+'''
+
+print(headerString)
+print("### Starting up NSMQ AI ###")
+print("### Step 1: Installing essential dependencies ###")
+run_dep = subprocess.Popen('pip install -q -r requirements.txt')
+run_dep.wait()
+
+if run_dep.returncode == 0:
+    print("### Step 2: Starting Up App ###")
+    start_app = subprocess.Popen('streamlit run NSMQ_AI.py')
+    start_app.wait()
+else:
+    print("Failed to install dependencies. Please resolve and try again.")

--- a/streamlitDemo/utility.py
+++ b/streamlitDemo/utility.py
@@ -9,6 +9,7 @@ import queue
 import base64
 import json
 import uuid
+import time
 
 # VIDEO PATHS
 DEMO_VIDEO_1_PATH = './assets/video/video1.mp4'
@@ -237,6 +238,7 @@ def realtime_audio_file_STT(audio_file_path, labelFlag="hidden"):
             sound_chunk.export(audio_chunk_temp_file, format ="wav")
             
             # Slicing of the audio file is done. transcribe audio chunks
+            time.sleep(2)
             transcriptText += get_stt_transcript(audio_chunk_temp_file)
             os.remove(audio_chunk_temp_file)
 


### PR DESCRIPTION
# Description
added script to simplify setup steps and modifications to align sample audio and stt transcript. Address issue #49 and #42 

- new script added that will replace the previous steps of installing the dependencies and also having to run the streamlit command to start the app
- once the virtual python environment is created user only needs to run the new script. It will install all the dependencies and then start the app automatically
- if there is an error installing the dependencies it will be displayed so the user can resolve it

# Testing
Manual Testing was done.

- Script failing if dependency issue is detected
![start script error](https://github.com/nsmq-ai/nsmqai/assets/10053339/e77ac169-7f98-4694-a0a0-e0b19b6080cb)

- Script passing
![start script pass](https://github.com/nsmq-ai/nsmqai/assets/10053339/9433b45f-c37b-4c93-888c-9145c46a9abf)

# Reviewers
@kojomensahonums @Nanayeb34 @AmoabaKelvin
