### PR TITLE
Rename QA Inference Notebook

### DIFF
--- a/question-answering/Embeddings_Database_For_Simple_Wikipedia_Passages.ipynb
+++ b/question-answering/Embeddings_Database_For_Simple_Wikipedia_Passages.ipynb
@@ -242,7 +242,7 @@
         "from chromadb.config import Settings\n",
         "from chromadb.utils import embedding_functions\n",
         "\n",
-        "# Specify embedding function\n",
+        "# Specify embedding function to use with ChromaDB. Should be the same as the one used for embedding passages.\n",
         "ef = embedding_functions.SentenceTransformerEmbeddingFunction(model_name=\"multi-qa-mpnet-base-dot-v1\")"
       ]
     },
@@ -309,29 +309,6 @@
       "cell_type": "code",
       "execution_count": null,
       "metadata": {
-        "id": "wAphC2SLXOKI"
-      },
-      "outputs": [],
-      "source": [
-        "def query_db(query, n_results=1):\n",
-        "  results = collection.query(\n",
-        "      query_texts=[query],\n",
-        "      n_results=n_results\n",
-        "  )\n",
-        "\n",
-        "  docs, scores = results[\"documents\"], results[\"distances\"]\n",
-        "  context = \"\"\n",
-        "  for doc in docs[0]:\n",
-        "    context += doc + \" | \"\n",
-        "  scores = round((sum(scores[0]))/n_results, 2)\n",
-        "\n",
-        "  return context, scores"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
         },
@@ -355,8 +332,8 @@
       "outputs": [],
       "source": [
         "# SETUP DATABASE\n",
-        "db = \"<DB NAME>\"\n",
-        "db_path = \"<PATH/TO/DB\" # DB Storage path\n",
+        "db = \"<DB NAME>\"    # Replace with prefered name for databse.\n",
+        "db_path = \"<PATH/TO/DB\" # Replace with prefered storage path for database (e.g., a location in Google Drive).\n",
         "path_to_db = os.path.join(db_path, \"Database\")\n",
         "client = chromadb.Client(Settings(chroma_db_impl=\"duckdb+parquet\", persist_directory=path_to_db))\n",
         "\n",
@@ -366,7 +343,8 @@
         "    collection = client.get_collection(name=db, embedding_function=ef)\n",
         "else:\n",
         "    if not os.path.isdir(path_to_db): os.mkdir(path_to_db)\n",
-        "    create_db(client, db, docs=passages[:10], ids=ids[:10], embds=corpus_embds[:10])\n",
+        "    # Create vector database for the first 10 elements.\n",
+        "    create_db(client, db, docs=passages[:10], ids=ids[:10])\n",
         "    collection = client.get_collection(name=db, embedding_function=ef)"
       ]
     },
@@ -1085,6 +1063,27 @@
         "  corpus_embds = model.encode(passages[start:end], batch_size=128, show_progress_bar=True)\n",
         "  corpus_embds = torch.from_numpy(corpus_embds)\n",
         "  create_db(client, db, passages[start:end], ids[start:end], corpus_embds)"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def query_db(query, n_results=1):\n",
+        "  results = collection.query(\n",
+        "      query_texts=[query],\n",
+        "      n_results=n_results\n",
+        "  )\n",
+        "\n",
+        "  docs, scores = results[\"documents\"], results[\"distances\"]\n",
+        "  context = \"\"\n",
+        "  for doc in docs[0]:\n",
+        "    context += doc + \" | \"\n",
+        "  scores = round((sum(scores[0]))/n_results, 2)\n",
+        "\n",
+        "  return context, scores"
       ]
     }
   ],

--- a/question-answering/QAML_Inference_API_Notebook.ipynb
+++ b/question-answering/QAML_Inference_API_Notebook.ipynb
@@ -270,8 +270,8 @@
       },
       "outputs": [],
       "source": [
-        "!ngrok config add-authtoken #YOUR AUTH TOKEN\n",
-        "!ngrok diagnose"
+        "# Replace comment section of code with your ngrok auth token\n",
+        "!ngrok config add-authtoken # place_your_ngrok_auth_token_here"
       ]
     },
     {


### PR DESCRIPTION
# Description

In this PR, we rename the QA API Inference Notebook to be more descriptive. We also refine the comments and sections of the code in the embeddings generation notebook.
1. The `QAML_Inference_API_Notebook.ipynb` allows one to set up a public API that one can then use in our Streamlit Web App to answer NSMQ riddles with our model.
2. The `Embeddings_Database_For_Simple_Wikipedia_Passages.ipynb` notebook allows one to efficiently embed and store passages from the Simple English Wikipedia dataset from Cohere using sentence transformers and ChromaDB. It also contains the necessary functions to allow one to build a simple semantic search engine with the vector database.

# Reviewers

@wsedor 
