### PR TITLE
Modified pages/Text_To_Speech:dropdown text option

### DIFF
--- a/streamlitDemo/pages/3_🔉_Text_To_Speech.py
+++ b/streamlitDemo/pages/3_🔉_Text_To_Speech.py
@@ -21,10 +21,7 @@ errorMsg = st.empty()
 # choose voice options
 voice = st.radio('Select A Voice', (TTS_VOICE_BANK['voice1'], TTS_VOICE_BANK['voice2']), horizontal=True)
 
-# text input
-#text = st.text_area("Enter Text", '', height = 80)
-
-# text input now a dropdown
+# text input-dropdown
 
 text= st.selectbox(
 'Select Text',
@@ -35,9 +32,6 @@ text= st.selectbox(
     
 )
 )
-
-#this fxn inherently does not allow you to leave box empty
-#apostrophe issues identified-how to make it read contracted words
 
 st.write('You selected:', text )
 

--- a/streamlitDemo/pages/3_🔉_Text_To_Speech.py
+++ b/streamlitDemo/pages/3_🔉_Text_To_Speech.py
@@ -22,7 +22,25 @@ errorMsg = st.empty()
 voice = st.radio('Select A Voice', (TTS_VOICE_BANK['voice1'], TTS_VOICE_BANK['voice2']), horizontal=True)
 
 # text input
-text = st.text_area("Enter Text", '', height = 80)
+#text = st.text_area("Enter Text", '', height = 80)
+
+# text input now a dropdown
+
+text= st.selectbox(
+'Select Text',
+(
+"I am the set of all possible positions a point can take. I may be a region in a plane or in space, but more often I am a continuous curve.Who am I?",
+"One particular element out of about the hundred or so elements in the Periodic Table is always present during my operations. I am the secret behind the relatively high boiling point of water. Who am i?",
+"Welcome to the national science and maths quiz.", "I am not one who likes much talk. I prefer action, so I'm on the side of forces. I am available when you need to turn things around and rotate objects about a point. Who am I?"
+    
+)
+)
+
+#this fxn inherently does not allow you to leave box empty
+#apostrophe issues identified-how to make it read contracted words
+
+st.write('You selected:', text )
+
 
 # generated audio file
 if st.button('Get Generated Speech!'):


### PR DESCRIPTION
# Description
Worked on TTS demo page updates for public demo:
-Replacing the text box with dropdown options for users to choose from to remove the security threat of input fields

# Testing
-I generated an API using the TTS Colab notebook in the Competition Notebook folder on Google Drive
-With sample riddles, I created different text options for testing
-Generated the audios using voice 1 and 2(audio samples below):
     -https://nsmqkwameaiproject.slack.com/files/U05TEKLGACF/F061CJNUXM4/download
     -https://nsmqkwameaiproject.slack.com/files/U05TEKLGACF/F061K5AHKD1/download.mp3

![Screenshot (350)](https://github.com/nsmq-ai/nsmqai/assets/48865208/4b5f1148-3758-4eb4-8ac7-671aed5f2e34)
![Screenshot (351)](https://github.com/nsmq-ai/nsmqai/assets/48865208/f42a4560-3034-4ea8-a309-f30e47e1a603)

# Reviewers
@jojoboateng @wsedor @Nanayeb34 

Kindly review the proposed changes


